### PR TITLE
fix: server config crash

### DIFF
--- a/common/src/main/java/com/ordana/immersive_weathering/configs/ClientConfigs.java
+++ b/common/src/main/java/com/ordana/immersive_weathering/configs/ClientConfigs.java
@@ -16,7 +16,6 @@ public class ClientConfigs {
 
     public static Supplier<Boolean> LEAF_DECAY_PARTICLES;
     public static Supplier<Boolean> FALLING_LEAF_PARTICLES;
-    public static Supplier<Boolean> CREATIVE_TAB;
 
     public static void init() {
         ConfigBuilder builder = ConfigBuilder.create(ImmersiveWeathering.res("client"), ConfigType.CLIENT);
@@ -24,7 +23,6 @@ public class ClientConfigs {
         builder.push("general");
         LEAF_DECAY_PARTICLES = builder.define("leaves_decay_particles", true);
         FALLING_LEAF_PARTICLES = builder.define("falling_leaf_particles", true);
-        CREATIVE_TAB = builder.define("creative_tab", false);
         builder.pop();
 
         CLIENT_SPEC = builder.buildAndRegister();

--- a/common/src/main/java/com/ordana/immersive_weathering/configs/CommonConfigs.java
+++ b/common/src/main/java/com/ordana/immersive_weathering/configs/CommonConfigs.java
@@ -16,6 +16,7 @@ public class CommonConfigs {
     public static ConfigSpec SERVER_SPEC;
 
     public static Supplier<Boolean> BLOCK_GROWTHS;
+    public static Supplier<Boolean> CREATIVE_TAB;
 
     public static Supplier<Double> MOSS_INTERESTS_FOR_FACE;
     public static Supplier<Double> MOSS_PATCHINESS;
@@ -97,6 +98,7 @@ public class CommonConfigs {
 
         builder.push("general");
         BLOCK_GROWTHS = builder.define("block_growths", true);
+        CREATIVE_TAB = builder.define("creative_tab", false);
         builder.pop();
 
         builder.push("mossy_blocks");

--- a/common/src/main/java/com/ordana/immersive_weathering/reg/ModItems.java
+++ b/common/src/main/java/com/ordana/immersive_weathering/reg/ModItems.java
@@ -2,7 +2,7 @@ package com.ordana.immersive_weathering.reg;
 
 import com.ordana.immersive_weathering.ImmersiveWeathering;
 import com.ordana.immersive_weathering.blocks.LeafPileBlock;
-import com.ordana.immersive_weathering.configs.ClientConfigs;
+import com.ordana.immersive_weathering.configs.CommonConfigs;
 import com.ordana.immersive_weathering.items.*;
 import com.ordana.immersive_weathering.items.materials.FlowerCrownMaterial;
 import com.ordana.immersive_weathering.items.materials.IcicleToolMaterial;
@@ -15,7 +15,7 @@ import java.util.function.Supplier;
 
 public class ModItems {
 
-    public static final CreativeModeTab MOD_TAB =  !ClientConfigs.CREATIVE_TAB.get() ? null :
+    public static final CreativeModeTab MOD_TAB =  !CommonConfigs.CREATIVE_TAB.get() ? null :
             PlatformHelper.createModTab(ImmersiveWeathering.res(ImmersiveWeathering.MOD_ID),
                     ()-> ModBlocks.IVY.get().asItem().getDefaultInstance(), false);
     


### PR DESCRIPTION
Move Creative Tab option to common config (was previously a client config option being accessed in the registry on the server, causing it to crash)