### PR TITLE
fix: move RandomBlockMatchTestAccessor to common mixins

### DIFF
--- a/common/src/main/resources/immersive_weathering-common.mixins.json
+++ b/common/src/main/resources/immersive_weathering-common.mixins.json
@@ -3,9 +3,7 @@
   "minVersion": "0.8",
   "package": "com.ordana.immersive_weathering.mixins",
   "compatibilityLevel": "JAVA_17",
-  "client": [
-    "accessors.RandomBlockMatchTestAccessor"
-  ],
+  "client": [],
   "mixins": [
     "BeeMixin",
     "BlocksMixin",
@@ -22,7 +20,8 @@
     "ServerLevelMixin",
     "SweetBerryBushMixin",
     "accessors.BiomeAccessor",
-    "accessors.IceInvoker"
+    "accessors.IceInvoker",
+    "accessors.RandomBlockMatchTestAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
RandomBlockMatchTestAccessor was being used in https://github.com/AstralOrdana/Immersive-Weathering/blob/1.18.2-Multiloader/common/src/main/java/com/ordana/immersive_weathering/data/block_growths/growths/ConfigurableBlockGrowth.java#L11 which is common code, causing a server crash when canGrow was called in a server environment