### PR TITLE
Added a set of configuration options to adjust the method of which so…

### DIFF
--- a/common/src/main/java/com/ordana/immersive_weathering/blocks/soil/MulchBlock.java
+++ b/common/src/main/java/com/ordana/immersive_weathering/blocks/soil/MulchBlock.java
@@ -83,8 +83,15 @@ public class MulchBlock extends FarmBlock {
 
         BlockState cropState = level.getBlockState(pos.above());
         if (CommonConfigs.MULCH_GROWS_CROPS.get() && level.getRawBrightness(pos.above(), 0) >= 9 && state.getValue(MulchBlock.MOISTURE) == 7) {
-            if(cropState.getBlock() instanceof CropBlock crop){
-                crop.growCrops(level, pos.above(), cropState);
+            if(CommonConfigs.MULCH_GROWTH_TYPE_BONEMEAL.get()) {
+                if (cropState.getBlock() instanceof CropBlock crop) {
+                    crop.growCrops(level, pos.above(), cropState);
+                }
+            }
+            else if(CommonConfigs.MULCH_GROWTH_TYPE_RANDOM_TICK.get()){
+                for(int i = 0; i<CommonConfigs.MULCH_GROWTH_RANDOM_TICKS.get(); i++){
+                    cropState.randomTick(level, pos.above(), random);
+                }
             }
         }
 

--- a/common/src/main/java/com/ordana/immersive_weathering/configs/CommonConfigs.java
+++ b/common/src/main/java/com/ordana/immersive_weathering/configs/CommonConfigs.java
@@ -99,6 +99,9 @@ public class CommonConfigs {
     public static Supplier<Boolean> RUST_STREAKING;
 
     public static Supplier<Boolean> MULCH_GROWS_CROPS;
+    public static Supplier<Boolean> MULCH_GROWTH_TYPE_BONEMEAL;
+    public static Supplier<Boolean> MULCH_GROWTH_TYPE_RANDOM_TICK;
+    public static Supplier<Integer> MULCH_GROWTH_RANDOM_TICKS;
 
 
     public static void init() {
@@ -188,6 +191,9 @@ public class CommonConfigs {
 
         builder.push("misc");
         MULCH_GROWS_CROPS = builder.define("mulch_grows_crops", true);
+        MULCH_GROWTH_TYPE_BONEMEAL = builder.define("mulch_growth_type_bonemeal", true);
+        MULCH_GROWTH_TYPE_RANDOM_TICK = builder.define("mulch_growth_type_random_tick", false);
+        MULCH_GROWTH_RANDOM_TICKS = builder.define("mulch_growth_random_ticks", 10, 1, 100);
         COMPOSTER_DIRT = builder.define("composter_dirt", true);
         DESIRE_PATHS = builder.define("desire_paths", false);
         DESIRE_PATH_RATE = builder.define("desire_path_rate", 0.05, 0, 1);


### PR DESCRIPTION
…aked mulch encourages plant growth.

The default option simulates bonemeal and does so every random tick of the mulch - which is the current mod functionality. The random tick option calls the randomTick function for the crop and does so a configurable amount of times.