### PR TITLE
Fixed Leaf Piles Chance

### DIFF
--- a/common/src/main/java/com/ordana/immersive_weathering/configs/CommonConfigs.java
+++ b/common/src/main/java/com/ordana/immersive_weathering/configs/CommonConfigs.java
@@ -71,6 +71,7 @@ public class CommonConfigs {
 
     public static final Supplier<Boolean> LEAF_PILES_SLOW;
     public static final Supplier<Double> LEAF_PILES_FROM_DECAY_CHANCE;
+    public static final Supplier<Double> LEAF_PILES_CHANCE;
     public static final Supplier<Integer> LEAF_PILE_MAX_HEIGHT;
     public static final Supplier<Integer> LEAF_PILES_REACH;
     public static final Supplier<List<String>> LEAF_PILES_BLACKLIST;
@@ -177,6 +178,7 @@ public class CommonConfigs {
         LEAF_PILES_SLOW = builder.define("leaf_piles_slow", true);
         LEAF_PILES_FROM_DECAY_CHANCE = builder.define("spawn_entity_from_decay", 0.3, 0, 1);
 
+        LEAF_PILES_CHANCE = builder.define("leaf_piles_spawn_chance", 0.005, 0, 1);
         LEAF_PILES_REACH = builder.define("reach", 12, 1, 256);
         LEAF_PILE_MAX_HEIGHT = builder.define("max_pile_height", 3, 1, 8);
         LEAF_PILES_BLACKLIST = builder.comment("leaves that wont spawn leaf piles").define("leaf_piles_blacklist", List.of());

--- a/common/src/main/java/com/ordana/immersive_weathering/data/block_growths/growths/builtin/LeavesGrowth.java
+++ b/common/src/main/java/com/ordana/immersive_weathering/data/block_growths/growths/builtin/LeavesGrowth.java
@@ -44,7 +44,7 @@ public class LeavesGrowth extends BuiltinBlockGrowth {
         //Drastically reduced this chance to help lag
         //checking if it has these properties because mcreator mods...
         if ((!state.hasProperty(LeavesBlock.PERSISTENT) || !state.getValue(LeavesBlock.PERSISTENT))
-                && random.nextFloat() < CommonConfigs.LEAF_PILES_REACH.get()) {
+                && random.nextFloat() < CommonConfigs.LEAF_PILES_CHANCE.get()) {
 
             var leafPile = WeatheringHelper.getFallenLeafPile(state).orElse(null);
             if (leafPile != null && level.getBlockState(pos.below()).isAir()) {


### PR DESCRIPTION
The option to modify leaf pile spawn chance was removed a while ago. This commit reintroduces it and also fixes a bug that made this variable useless in the past. Instead of checking for LEAF_PILES_CHANCE before spawning a leaf, the code was comparing a random.nextFloat() with LEAF_PILES_REACH, but this value is always >= 1.0, so the piles were always spawning. 