### PR TITLE
PR to address Issue #391: Snowy stone blocks fix for seasonal mods

### DIFF
--- a/common/src/main/java/com/ordana/immersive_weathering/util/TemperatureManager.java
+++ b/common/src/main/java/com/ordana/immersive_weathering/util/TemperatureManager.java
@@ -4,55 +4,34 @@ import com.ordana.immersive_weathering.reg.ModTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.tags.BiomeTags;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 
 import java.util.function.Supplier;
 
 public class TemperatureManager {
-//TODO: add more uses. consider local and global temperature
-    //biome coldEnoght to snow internally calls get temp <0.15
-
-    //same temperature as jungle
-    private static final float SNOW_MELT_TEMPERATURE = 0.95f;
-    private static final float SNOW_GROW_TEMPERATURE = 0.15f; //one uses for coldEnoughtToSnow
 
     public static boolean snowGrowthCanGrowSnowyBlock(BlockPos pos, Supplier<Holder<Biome>> biome) {
         return biome.get().value().coldEnoughToSnow(pos);
     }
 
     public static boolean canSnowMelt(BlockPos pos, Level level) {
-        //TODO: rethink. Use biome temperature using biome.getTemperature as well as taking into accoutn more local conditions
+        //warmEnoughToRain should be sufficient to turn back snowy blocks for season mods and works as intended where snow should melt if it rains.
         Holder<Biome> biome = level.getBiome(pos);
-        return biome.is(BiomeTags.SNOW_GOLEM_MELTS) || //Unneded really, just here for redundancy
-                getTemperature(pos, biome.value()) >= SNOW_MELT_TEMPERATURE;
+        return biome.value().warmEnoughToRain(pos);
     }
-
 
     public static boolean hasSandstorm(ServerLevel level, BlockPos pos) {
         return level.isRaining() && level.getBiome(pos).is(ModTags.HAS_SANDSTORM);
     }
 
-    private static float getTemperature(BlockPos pos, Biome biome) {
-        return biome.getTemperature(pos);
-    }
-
-    public static float getLocalTemperature(ServerLevel level, BlockPos pos, Biome biome){
-        float local = getTemperature(pos, biome);
-
-        return local;
-    }
-
-
-    /**
+    /*
      * Use Cases:
      *
      * Snowy blocks melting
      * Snowy blocks forming
      * Icicle melting
      * Icicle forming
-     *
      *
      */
 


### PR DESCRIPTION
This pull request addresses Issue #391 

I followed the same logic as a commit 30e29f2. Snow should melt above the in-game freezing point of .15f to follow vanilla MC logic. Current code will not allow snowy stone blocks to melt unless they are in a biome with a temperature over 0.95f. 

I removed the static variables as they are defined by warmEnoughToRain in the base code. I removed getTemperature methods since they aren't used/needed. 