### PR TITLE
Fixes falling_ash particles dropping from leaf piles passively while over water

### DIFF
--- a/common/src/main/java/com/ordana/immersive_weathering/blocks/LeafPileBlock.java
+++ b/common/src/main/java/com/ordana/immersive_weathering/blocks/LeafPileBlock.java
@@ -117,6 +117,11 @@ public class LeafPileBlock extends LayerBlock implements BonemealableBlock {
     }
 
     @Override
+    public void animateTick(BlockState state, Level level, BlockPos pos, RandomSource rand) {
+     // shh
+    }
+    
+    @Override
     public void entityInside(BlockState state, Level level, BlockPos pos, Entity entity) {
         int layers = this.getLayers(state);
 


### PR DESCRIPTION
I'm not super fluent on minecraft code but I belive FallingBlocks animateTick only exist to spawn dust particles(?)

overriding and removing the method removes the client generation of dust particles while height1 leaf piles are over water.

correct me if there is something important I missed about animateTick